### PR TITLE
gpt-utils: Open block device read only when obtaining info

### DIFF
--- a/gpt-utils.c
+++ b/gpt-utils.c
@@ -403,7 +403,7 @@ static int gpt_get_headers(const char *partname, uint8_t **primary, uint8_t **ba
 		goto error;
 	}
 
-	fd = open(devpath, O_RDWR);
+	fd = open(devpath, O_RDONLY);
 	if (fd < 0) {
 		fprintf(stderr, "%s: Failed to open %s : %s\n", __func__, devpath, strerror(errno));
 		return -1;
@@ -638,7 +638,7 @@ int gpt_disk_get_disk_info(const char *dev, struct gpt_disk *disk)
 
 	disk->hdr_bak_crc = efi_crc32(disk->hdr_bak, gpt_header_size);
 
-	fd = open(disk->devpath, O_RDWR);
+	fd = open(disk->devpath, O_RDONLY);
 	if (fd < 0) {
 		fprintf(stderr, "%s: Failed to open %s: %s\n", __func__, disk->devpath,
 			strerror(errno));


### PR DESCRIPTION
Otherwise reading information like `qbootctl -a` triggers removal and readdition of all partitions like:

```
KERNEL[73264.679695] remove   /devices/platform/soc@0/1d84000.ufshc/host0/target0:0:0/0:0:0:4/block/sde/sde11 (block)
KERNEL[73264.748249] add      /devices/platform/soc@0/1d84000.ufshc/host0/target0:0:0/0:0:0:4/block/sde/sde11 (block)
KERNEL[73264.863286] remove   /devices/platform/soc@0/1d84000.ufshc/host0/target0:0:0/0:0:0:4/block/sde/sde11 (block)
KERNEL[73264.917664] add      /devices/platform/soc@0/1d84000.ufshc/host0/target0:0:0/0:0:0:4/block/sde/sde11 (block)
UDEV  [73264.980859] remove   /devices/platform/soc@0/1d84000.ufshc/host0/target0:0:0/0:0:0:4/block/sde/sde11 (block)
UDEV  [73265.150742] add      /devices/platform/soc@0/1d84000.ufshc/host0/target0:0:0/0:0:0:4/block/sde/sde11 (block)
UDEV  [73265.276134] remove   /devices/platform/soc@0/1d84000.ufshc/host0/target0:0:0/0:0:0:4/block/sde/sde11 (block)
UDEV  [73265.492442] add      /devices/platform/soc@0/1d84000.ufshc/host0/target0:0:0/0:0:0:4/block/sde/sde11 (block)
…[the same for all other partitions on sde]…
```

leading to wasted CPU cycles (and battery) but also making programms that run right after that command and accessing one of the partitions fail sporadically. This can be bad if those commands are e.g. doing a

```
cat /dev/disk/by-partlabel/boot_a
```

to backup the current boot partition.