### PR TITLE
Do not fail on qbootctl -m if device is not A/B

### DIFF
--- a/bootctrl_impl.c
+++ b/bootctrl_impl.c
@@ -410,8 +410,10 @@ int mark_boot_successful(unsigned slot)
 	int ret = 0;
 
 	if (successful < 0 || unbootable < 0) {
-		fprintf(stderr, "SLOT %s: Failed to read attributes\n", slot_suffix_arr[slot]);
-		ret = -1;
+		fprintf(stderr,
+			"SLOT %s: Failed to read attributes - the device is probably not A/B partitioned\n",
+			slot_suffix_arr[slot]);
+		ret = -ENODEV;
 		goto out;
 	}
 

--- a/qbootctl.c
+++ b/qbootctl.c
@@ -194,10 +194,12 @@ int main(int argc, char **argv)
 		return 0;
 	case 'm':
 		rc = impl->markBootSuccessful(slot);
-		if (rc < 0)
+		if (rc == -ENODEV)
+			printf("Did not mark any boot as successful, not necessary\n");
+		else if (rc < 0)
 			return 1;
-		printf("SLOT %s: Marked boot successful\n",
-		       impl->getSuffix(slot));
+		else
+			printf("SLOT %s: Marked boot successful\n", impl->getSuffix(slot));
 		return 0;
 	case 'u':
 		rc = impl->setSlotAsUnbootable(slot);


### PR DESCRIPTION
It is common and makes sense to ship `qbootctl -m` as some kind of init service that runs at boot. However, not all devices are A/B partitioned and `qbootctl -m` will currently return an exit code of 1 on these devices, making the init service marked as failed. We should handle this case more gracefully and exit with exit code 0 if there was nothing to do.